### PR TITLE
Add hidden form field for honeypot

### DIFF
--- a/components/ContactForm.js
+++ b/components/ContactForm.js
@@ -26,6 +26,9 @@ export default function ContactForm({ form, handleChange, processForm, submitSta
                     netlify-honeypot="bot-field"
                     onSubmit={processForm}
                 >
+                    <p className="hidden">
+                        <label>Don’t fill this out if you’re human: <input name="bot-field" /></label>
+                    </p>
                     <Form.Field
                         id='name'
                         name='name'

--- a/components/ContactForm.js
+++ b/components/ContactForm.js
@@ -27,7 +27,7 @@ export default function ContactForm({ form, handleChange, processForm, submitSta
                     onSubmit={processForm}
                 >
                     <p className="hidden">
-                        <label>Don’t fill this out if you’re human: <input name="bot-field" /></label>
+                        <label>Don’t fill this out if you’re human: <input onChange={handleChange} name="bot-field" /></label>
                     </p>
                     <Form.Field
                         id='name'

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -22,12 +22,13 @@ export default function Contact({ info }) {
         name: "",
         message: "",
         email: "",
+        "bot-field": "",
     })
 
     const handleChange = event => {
         updateForm({
             ...form,
-            [event.target.id]: event.target.value
+            [event.target.name]: event.target.value
         });
     }
     

--- a/styles/components/_ContactForm.scss
+++ b/styles/components/_ContactForm.scss
@@ -1,0 +1,5 @@
+form {
+    & > .hidden {
+        display: none;
+    }
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -19,6 +19,7 @@ a {
   margin-bottom: 2em;
 }
 
+@import 'components/ContactForm';
 @import 'components/PostPreview';
 @import 'components/PostBody';
 @import 'setup/typography';


### PR DESCRIPTION
As per [Netlify docs](https://docs.netlify.com/forms/spam-filters/#honeypot-field). Form needs a hidden field for bots to fill out.